### PR TITLE
Bug/rpro 1090

### DIFF
--- a/Red5ProiOS/Main.storyboard
+++ b/Red5ProiOS/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9059" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="1pY-b2-Ywk">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="14F1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="1pY-b2-Ywk">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
     </dependencies>
     <scenes>
@@ -567,7 +567,7 @@
                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="11"/>
                                                         <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                     </label>
-                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="live" textAlignment="center" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="dws-Fr-MBQ">
+                                                    <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="---" textAlignment="center" minimumFontSize="12" translatesAutoresizingMaskIntoConstraints="NO" id="dws-Fr-MBQ">
                                                         <rect key="frame" x="70" y="-1" width="101" height="34"/>
                                                         <color key="textColor" red="0.89019607840000003" green="0.098039215690000001" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>

--- a/Red5ProiOS/Red5ProiOS-Info.plist
+++ b/Red5ProiOS/Red5ProiOS-Info.plist
@@ -2,11 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -22,13 +17,18 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.8</string>
+	<string>1.0.9</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.8</string>
+	<string>1.0.9</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/Red5ProiOS/SettingsViewController.m
+++ b/Red5ProiOS/SettingsViewController.m
@@ -18,8 +18,6 @@
 
 - (NSString*) getUserSetting:(NSString *)key withDefault:(NSString *)defaultValue {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *appDomain = [[NSBundle mainBundle] bundleIdentifier];
-    [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:appDomain];
     if([defaults objectForKey:key]) {
         return [defaults stringForKey:key];
     }

--- a/Red5ProiOS/SettingsViewController.m
+++ b/Red5ProiOS/SettingsViewController.m
@@ -18,6 +18,8 @@
 
 - (NSString*) getUserSetting:(NSString *)key withDefault:(NSString *)defaultValue {
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    NSString *appDomain = [[NSBundle mainBundle] bundleIdentifier];
+    [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:appDomain];
     if([defaults objectForKey:key]) {
         return [defaults stringForKey:key];
     }
@@ -66,7 +68,6 @@
     
     self.domain.text = [self getUserSetting:@"domain" withDefault:@"0.0.0.0"];
     self.port.text = [self getUserSetting:@"port" withDefault:self.port.text];
-    self.app.text = [self getUserSetting:@"app" withDefault:self.app.text];
     self.stream.text = [self getUserSetting:@"stream" withDefault:self.stream.text];
     self.protocol.text = [self getUserSetting:@"protocol" withDefault:self.protocol.text];
     self.bitrate.text = [self getUserSetting:@"bitrate" withDefault:@"128"];
@@ -79,16 +80,19 @@
             [self.streamSettingsForm setHidden:NO];
             [self.publishSettingsForm setHidden:NO];
             self.port.text = [self getUserSetting:@"port" withDefault:@"8554"];
+            self.app.text = [self getUserSetting:@"app" withDefault:@"live"];
             break;
         case r5_example_stream:
             [self.streamSettingsForm setHidden:NO];
             [self.publishSettingsForm setHidden:YES];
             self.port.text = [self getUserSetting:@"port" withDefault:@"8554"];
+            self.app.text = [self getUserSetting:@"app" withDefault:@"live"];
             break;
         case r5_example_secondscreen:
             [self.streamSettingsForm setHidden:YES];
             [self.publishSettingsForm setHidden:YES];
             self.port.text = [self getUserSetting:@"secondscreen_port" withDefault:@"8088"];
+            self.app.text = [self getUserSetting:@"app" withDefault:@"secondscreen"];
             break;
     }
 


### PR DESCRIPTION
Fix for RPRO-1090 to show `secondscreen` as app setting when in Second Screen section.

Be sure to remove previous build from phone when testing, otherwise it will still show `live` as that has previously been stored as user default.